### PR TITLE
Add GitHub Actions CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Modulr CI
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.12
+      - name: Install Hatch
+        run: pipx install hatch
+      - name: Run Hatch CI
+        run: hatch run test
+        shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,5 @@ python = "3.12"
 dependencies = ["black"]
 
 [tool.hatch.envs.default.scripts]
-test = """for dir in testsuite/*/; do
-	python modulr.py $dir 1>/dev/null
-    python testsuite/checkresults.py $dir
-done"""
+test = "bash test-suite.sh"
 format = "black ."

--- a/test-suite.sh
+++ b/test-suite.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for dir in testsuite/*/; do
+	python modulr.py $dir 1>/dev/null
+	python testsuite/checkresults.py $dir
+done
+

--- a/testsuite/checkresults.py
+++ b/testsuite/checkresults.py
@@ -16,6 +16,8 @@ testrun_root = Path(sys.argv[1])
 output_root = testrun_root / "site"
 expect_root = testrun_root / "expected"
 
+has_failures: bool = False
+
 for root, dirs, files in output_root.walk(on_error=print):
     filepaths = [root / file for file in files]
     for fp in filepaths:
@@ -27,6 +29,7 @@ for root, dirs, files in output_root.walk(on_error=print):
                 try:
                     assert output_file.read() == expect_file.read()
                 except AssertionError:
+                    has_failures = True
                     print(
                         f"Test {str(testrun_root).removeprefix('testsuite/')} - {fp}: Fail"
                     )
@@ -34,3 +37,7 @@ for root, dirs, files in output_root.walk(on_error=print):
                     print(
                         f"Test {str(testrun_root).removeprefix('testsuite/')} - {fp}: Pass"
                     )
+if has_failures:
+    sys.exit(1)
+else:
+    sys.exit(0)


### PR DESCRIPTION
I added a github actions workflow for running the test suite on PRs and direct pushes to both dev and main.

For some reason, the bash shell on the windows runner doesn't work when the shell script is a string in the hatch run command, but it works when it's executed as a script, so I also added a `test-suite.sh` script that is run by hatch in order to get the same test suite behavior on Linux, MacOS, and Windows.

I also added an exit code to the `checkresults.py` script so that failed tests will properly trigger a failure in the CI.